### PR TITLE
update installer to copy .htaccess file

### DIFF
--- a/src/SeerUK/Composer/PimcoreInstaller.php
+++ b/src/SeerUK/Composer/PimcoreInstaller.php
@@ -122,29 +122,27 @@ EOF;
     }
 
     /**
-     * copy the .htaccess file if it does not exist
+     * Copy the Pimcore default .htaccess file to the 'document-root-path' if it does not exist
      *
      * @param Event $event
      *
      * @return void
      */
-    public static function copyHtAccessFile(Event $event)
+    public static function installHtAccessFile(Event $event)
     {
         list($installPath, $vendorPath) = self::prepareBaseDirectories($event);
-
-        if (file_exists($vendorPath . "/pimcore/pimcore/.htaccess")) {
-            $from = $vendorPath . "/pimcore/pimcore/.htaccess";
-        } elseif (file_exists($vendorPath . "/pimcore/pimcore/website_example/.htaccess")) {
-            $from = $vendorPath . "/pimcore/pimcore/website_example/.htaccess";
-        } else {
-            // we don't know about the .htaccess file.
-            return;
-        }
 
         $to = $installPath . "/.htaccess";
 
         if (file_exists($to)) {
             // .htaccess already exists, don't copy it
+            return;
+        }
+
+        if (file_exists($vendorPath . "/pimcore/pimcore/.htaccess")) {
+            $from = $vendorPath . "/pimcore/pimcore/.htaccess";
+        } else {
+            // unknown .htaccess file location within pimcore
             return;
         }
 

--- a/src/SeerUK/Composer/PimcoreInstaller.php
+++ b/src/SeerUK/Composer/PimcoreInstaller.php
@@ -132,16 +132,10 @@ EOF;
     {
         list($installPath, $vendorPath) = self::prepareBaseDirectories($event);
 
+        $from = $vendorPath . "/pimcore/pimcore/.htaccess";
         $to = $installPath . "/.htaccess";
 
-        if (file_exists($to)) {
-            // .htaccess already exists, don't copy it
-            return;
-        }
-
-        if (file_exists($vendorPath . "/pimcore/pimcore/.htaccess")) {
-            $from = $vendorPath . "/pimcore/pimcore/.htaccess";
-        } else {
+        if (!file_exists($from)) {
             // unknown .htaccess file location within pimcore
             return;
         }
@@ -151,6 +145,8 @@ EOF;
 
     /**
      * Prepare base directories for copying and installation
+     *
+     * @param Event $event
      *
      * @return array
      */

--- a/src/SeerUK/Composer/PimcoreInstaller.php
+++ b/src/SeerUK/Composer/PimcoreInstaller.php
@@ -122,6 +122,36 @@ EOF;
     }
 
     /**
+     * copy the .htaccess file if it does not exist
+     *
+     * @param Event $event
+     *
+     * @return void
+     */
+    public static function copyHtAccessFile(Event $event)
+    {
+        list($installPath, $vendorPath) = self::prepareBaseDirectories($event);
+
+        if (file_exists($vendorPath . "/pimcore/pimcore/.htaccess")) {
+            $from = $vendorPath . "/pimcore/pimcore/.htaccess";
+        } elseif (file_exists($vendorPath . "/pimcore/pimcore/website_example/.htaccess")) {
+            $from = $vendorPath . "/pimcore/pimcore/website_example/.htaccess";
+        } else {
+            // we don't know about the .htaccess file.
+            return;
+        }
+
+        $to = $installPath . "/.htaccess";
+
+        if (file_exists($to)) {
+            // .htaccess already exists, don't copy it
+            return;
+        }
+
+        copy($from, $to);
+    }
+
+    /**
      * Prepare base directories for copying and installation
      *
      * @return array


### PR DESCRIPTION
adds in functionality to copy over pimcore's default .htaccess file on postInstall/postUpdate.
