### PR TITLE
Download Pimcore without Composer to avoid autoloading conflicts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+cache/
+!cache/.gitkeep
 vendor/
 composer.lock

--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
 Pimcore Composer Installer
 ==========================
 
-Installs Pimcore to your configured `document-root-path` via Composer.
+Installs a given version of Pimcore to your configured `document-root-path` via Composer. The main
+goal of this package is to make it easier to ramp developers up onto a Pimcore project, and make it
+easier to set up Pimcore projects. It achieves this by ensuring that you don't have to commit 
+Pimcore to your project's repository, and automates the task of downloading, extracting, and placing
+the Pimcore files in your project.
 
-## Example usage:
+## Usage:
+
+Two config entries are required in your project's composer.json file:
+
+* `document-root-path`: This is the Pimcore web-root, i.e. where index.php will be, and where files
+will be served from.
+* `pimcore-version`: This is the exact Pimcore version that you want to use. This cannot be part of
+your project's required dependenies because the version downloaded by Composer would clash with the
+Pimcore autoloader.
+
+You must then also specify the installer as `post-install-cmd` and `post-update-cmd` scripts.
+
+For example:
 
 ```
 {
     ...
     "config": {
-        "document-root-path": "./web"
+        "document-root-path": "./web",
+        "pimcore-version": "3.1.1"
     },
     "require": {
-        "pimcore/pimcore": "^3.1",
         "byng/pimcore-composer-installer": "^1.0"
     },
     "scripts": {
@@ -28,7 +44,9 @@ Installs Pimcore to your configured `document-root-path` via Composer.
 ```
 
 The `Installer` class has methods for installing individual components, this makes it very easy to
-tailor the installation to your project's needs.
+tailor the installation to your project's needs. If you are planning on using these methods, make
+sure you first always called the `download` method, all of the install methods will need it to have
+been called first by Composer.
 
 Note: This plugin will overwrite some files without warning. If you have modified default Pimcore 
 code then you will more than likely lose it. We recommend extending the Pimcore code to augment the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Two config entries are required in your project's composer.json file:
 * `document-root-path`: This is the Pimcore web-root, i.e. where index.php will be, and where files
 will be served from.
 * `pimcore-version`: This is the exact Pimcore version that you want to use. This cannot be part of
-your project's required dependenies because the version downloaded by Composer would clash with the
+your project's required dependencies because the version downloaded by Composer would clash with the
 Pimcore autoloader.
 
 You must then also specify the installer as `post-install-cmd` and `post-update-cmd` scripts.


### PR DESCRIPTION
A necessary evil, but it works, and is actually pretty quick. This is of course yet another breaking change, so I think this is going to be a 3.0 issue.
